### PR TITLE
Fix bug in AsByteSequence implementation for String

### DIFF
--- a/src/auto/mod.rs
+++ b/src/auto/mod.rs
@@ -331,8 +331,8 @@ impl AsByteSequence for String {
         log::trace!("Deserializing string of unknown length");
 
         let end = match memchr::memrchr(0, bytes) {
-            Some(posn) => posn - 1,
-            None => bytes.len() - 1,
+            Some(posn) => posn,
+            None => bytes.len(),
         };
 
         let s = String::from_utf8_lossy(&bytes[..end]).to_string();


### PR DESCRIPTION
This fixes a small bug in the AsByteSequence implementation for String which caused the library to panic when receiving and empty string property when calling `get_property()`.