### PR TITLE
Return an error when the connection is closed

### DIFF
--- a/breadx/src/connection/sendmsg.rs
+++ b/breadx/src/connection/sendmsg.rs
@@ -126,6 +126,11 @@ impl SendmsgConnection {
 
         // process the infomration
         let bytes_read = msg.bytes;
+
+        if bytes_read == 0 {
+            return Err(Error::make_disconnected());
+        }
+
         let mut cloexec_result = Ok(());
         fds.extend(
             msg.cmsgs()

--- a/breadx/src/connection/sendmsg.rs
+++ b/breadx/src/connection/sendmsg.rs
@@ -104,7 +104,7 @@ impl SendmsgConnection {
         let span = tracing::trace_span!("recvmsg");
         let _enter = span.enter();
 
-        if !iov.iter().any(|slice| !slice.is_empty()) {
+        if iov.iter().all(|slice| slice.is_empty()) {
             return Ok(0);
         }
 

--- a/breadx/src/connection/sendmsg.rs
+++ b/breadx/src/connection/sendmsg.rs
@@ -104,7 +104,7 @@ impl SendmsgConnection {
         let span = tracing::trace_span!("recvmsg");
         let _enter = span.enter();
 
-        if iov.is_empty() {
+        if !iov.iter().any(|slice| !slice.is_empty()) {
             return Ok(0);
         }
 


### PR DESCRIPTION
When the X11 server closes the connection, `recvmsg` immediately returns with a length of `0` which currently causes an infinite loop. These changes fix that by returning a `Disconnected` error instead.